### PR TITLE
Enable building on BSD systems

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,10 @@
 default: libwhich
 
 override CFLAGS += -std=gnu99 -D_GNU_SOURCE
+ifeq (,$(findstring $(shell uname),FreeBSD OpenBSD NetBSD DragonFly))
+# BSD systems include libdl as part of libc
 override LDFLAGS += -ldl
+endif
 
 libwhich: libwhich.o
 	$(CC) $< -o $@ $(LDFLAGS)


### PR DESCRIPTION
This allows building libwhich to succeed on BSD systems, e.g. FreeBSD and DragonFly, where libdl is part of libc rather than its own library. However, the tests do not pass, even with `gsed`, since the tests reference libdl. Commenting out all tests that involve libdl allows the remaining tests to pass.