### PR TITLE
enable building and testing on BSD systems

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,10 @@
 default: libwhich
 
 override CFLAGS += -std=gnu99 -D_GNU_SOURCE
+override LDFLAGS +=
+ifeq ($(shell uname),Linux)
 override LDFLAGS += -ldl
+endif
 
 libwhich: libwhich.o
 	$(CC) $< -o $@ $(LDFLAGS)


### PR DESCRIPTION
libdl is not required (or provided) on BSD systems (closes #1, with tests 🙂)