### PR TITLE
OpenBSD

### DIFF
--- a/libwhich.c
+++ b/libwhich.c
@@ -227,7 +227,7 @@ const char *dlpath(void *handle, struct vector_t name)
         void *h2 = dlopen(name.data[i], RTLD_LAZY);
         if (h2)
             dlclose(h2);
-        // If the handle is the same as what was passed in (modulo mode bits), return this image name
+        // If the handle is the same as what was passed in, return this image name
         if (((intptr_t)handle & (-4)) == ((intptr_t)h2 & (-4)))
             return name.data[i];
     }

--- a/libwhich.c
+++ b/libwhich.c
@@ -328,11 +328,13 @@ int main(int argc, STR *argv)
     void *lib = dlopen(libname, RTLD_LAZY);
     if (!lib) {
         fputs(T("failed to open library: "), stdout);
-#ifdef _WIN32
+#if defined(_WIN32)
         fputs(T("LoadLibrary("), stdout);
         fputs(libname, stdout);
         fputs(T("): "), stdout);
-
+#elif defined(__OpenBSD__)
+        fputs(libname, stdout);
+        fputs(" ", stdout);
 #endif
         fputs(dlerror(), stdout);
         putchar('\n');

--- a/libwhich.c
+++ b/libwhich.c
@@ -211,7 +211,7 @@ struct vector_t dllist()
     return dynamic_libraries;
 }
 
-#if defined(__linux__) || defined(__FreeBSD__) # Use `dlinfo` API, when supported
+#if defined(__linux__) || defined(__FreeBSD__)  // Use `dlinfo` API, when supported
 const char *dlpath(void *handle, struct vector_t name)
 {
     struct link_map *map;

--- a/libwhich.c
+++ b/libwhich.c
@@ -211,7 +211,7 @@ struct vector_t dllist()
     return dynamic_libraries;
 }
 
-#ifdef dlinfo
+#if defined(__linux__) || defined(__FreeBSD__) # Use `dlinfo` API, when supported
 const char *dlpath(void *handle, struct vector_t name)
 {
     struct link_map *map;

--- a/libwhich.c
+++ b/libwhich.c
@@ -228,7 +228,7 @@ const char *dlpath(void *handle, struct vector_t name)
         if (h2)
             dlclose(h2);
         // If the handle is the same as what was passed in, return this image name
-        if (((intptr_t)handle & (-4)) == ((intptr_t)h2 & (-4)))
+        if (handle == h2)
             return name.data[i];
     }
     return NULL;


### PR DESCRIPTION
Let libwhich compile and run on OpenBSD.

While here, dlerror(3) on OpenBSD doesn't insert the library's name, so do so manually in order to unify error output on Unix-y platforms.

"make check SED=gsed" doesn't pass due to "./libwhich" not being matched in the sed statements due to the leading dot; however, the resulting program seems to run more or less without issue, and allows me to fail much further along when attempting to build Julia.