### PR TITLE
fix on musl

### DIFF
--- a/test-libwhich.sh
+++ b/test-libwhich.sh
@@ -86,7 +86,7 @@ S=$(dotest ./libwhich -a libz.$SHEXT | $GREP -aF "$S") # make sure -p appears in
 echo RESULT: $S
 [ -n "$S" ] || exit 1
 
-S=`dotest ./libwhich -a libz.$SHEXT | $SED -e 's/\x00.*//'` # get an existing shared library path
+S=`dotest ./libwhich -a libz.$SHEXT | $SED -e 's/\x00.*//'` # get an existing (the first) shared library path
 echo RESULT: $S
 [ -n "$S" ] || exit 1
 stat "$S"


### PR DESCRIPTION
Alpine Linux / musl libc outputs the program name as the first shared-library.
Rather than skip NULL entries, record all, then skip the first (which appears to be the program name on all systems).

fix #6